### PR TITLE
Increase CSS specificity for color override rules

### DIFF
--- a/environmentlabel/services/EnvironmentLabelService.php
+++ b/environmentlabel/services/EnvironmentLabelService.php
@@ -118,7 +118,7 @@ class EnvironmentLabelService extends BaseApplicationComponent
             // Optionally override the label color
             if (!empty($labelColor))
             {
-                craft()->templates->includeCss('body:before { background-image: none; background-color: '. $labelColor . '; }');
+                craft()->templates->includeCss('html body:before { background-image: none; background-color: '. $labelColor . '; }');
             }
 
             // Optionally override the label text color


### PR DESCRIPTION
In some views the override css was overwritten by the original style. For example in the entry types field layout design view.