### PR TITLE
Css align better with the craft cms sidebar

### DIFF
--- a/environmentlabel/resources/environmentlabel.css
+++ b/environmentlabel/resources/environmentlabel.css
@@ -5,7 +5,7 @@ body:before {
     color: #ffffff;
     text-align: right;
     text-transform: uppercase;
-    padding: 20px 24px;
+    padding: 16px 24px;
     font-size: 15px;
     font-weight: 700;
     z-index: 9;


### PR DESCRIPTION
Update css to align better with the craft cms sidebar. Now the banner has the same height as the bounding box of the page title in the left sidebar – looks better. :)